### PR TITLE
internal_showtime_id is Back Mandatory

### DIFF
--- a/prisma/migrations/20231103130834_internal_showtime_id_is_back_mandatory/migration.sql
+++ b/prisma/migrations/20231103130834_internal_showtime_id_is_back_mandatory/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `internal_showtime_id` on table `Showtime` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Showtime" ALTER COLUMN "internal_showtime_id" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 
 model Showtime {
   id                   Int      @id @default(autoincrement())
-  internal_showtime_id Int?
+  internal_showtime_id Int
   movie                String
   date                 DateTime
   format               String?

--- a/src/data-sources/oskar/services/oskar-showtimes.service.ts
+++ b/src/data-sources/oskar/services/oskar-showtimes.service.ts
@@ -28,13 +28,15 @@ export class OskarShowtimesService implements DataSourceShowtimesService {
       const time = times[i].querySelector('span.time')?.text
       if (!time) continue
 
+      const showtimeLink = times[i].getAttribute('href')
+
+      const internalShowtimeId: number = parseInt(showtimeLink.split('&')[1].split('=')[1])
       const combinedDate = combineDateWithTime(date, time)
-
       const combinedFormats: string = combineFormatElements(formats[i])
-
-      const orderLink = `https://oskar.kyiv.ua${times[i].getAttribute('href')}`
+      const orderLink = `https://oskar.kyiv.ua${showtimeLink}`
 
       const processedShowtime: CreateShowtimeDto = {
+        internal_showtime_id: internalShowtimeId,
         movie: movieName,
         date: combinedDate,
         format: combinedFormats,

--- a/src/showtimes/dtos/create-showtime.dto.ts
+++ b/src/showtimes/dtos/create-showtime.dto.ts
@@ -1,5 +1,5 @@
 export class CreateShowtimeDto {
-  internal_showtime_id?: number
+  internal_showtime_id: number
   movie: string
   date: Date
   format?: string


### PR DESCRIPTION
Optional internal_showtime_id is breaking Oskar's unique constraint logic checking inside ShowtimesService, so it was decided to make it mandatory